### PR TITLE
Use code quotations to build queries

### DIFF
--- a/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
+++ b/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
@@ -74,6 +74,9 @@
     <Compile Include="MongoClient.fs">
       <Link>MongoClient.fs</Link>
     </Compile>
+    <Compile Include="QuotableMongo.fs">
+      <Link>QuotableMongo.fs</Link>
+    </Compile>
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
+++ b/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
@@ -53,6 +53,9 @@
     <Compile Include="Properties/AssemblyInfo.fs">
       <Link>Properties/AssemblyInfo.fs</Link>
     </Compile>
+    <Compile Include="Serialization/FSharpTypeSerializer.fs">
+      <Link>Serialization/FSharpTypeSerializer.fs</Link>
+    </Compile>
     <Compile Include="MongoOperationSettings.fs">
       <Link>MongoOperationSettings.fs</Link>
     </Compile>

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -348,7 +348,14 @@ module Quotations =
                 BsonElement("$addToSet", BsonDocument(field, BsonDocument("$each", BsonArray(values))))
 
             | Lambda (_, Lambda (_, SpecificCall <@ Update.push @> _)) ->
-                BsonElement("$push", BsonDocument(field, BsonDocument("$each", BsonArray(values))))
+                let array =
+                    try
+                        BsonArray(values |> List.map BsonValue.Create)
+                    with
+                       | :? System.ArgumentException ->
+                            BsonArray(values |> List.map (fun x -> x.ToBsonDocument(x.GetType()) :> BsonValue))
+
+                BsonElement("$push", BsonDocument(field, BsonDocument("$each", array)))
 
             | _ -> failwith "unrecognized operation with Update.each"
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -157,6 +157,9 @@ module Quotations =
                 | :? BsonType as typ -> BsonElement(field, BsonDocument("$type", BsonValue.Create typ))
                 | _ -> failwith "expected bson type"
 
+            | Let (_, Int32(value), Lambda(_, SpecificCall <@ Query.size @> _)) ->
+                BsonElement(field, BsonDocument("$size", BsonInt32(value)))
+
             | _ -> failwith "unrecognized expression"
 
         | SpecificCall <@ Query.nor @> (_, _, [ List (subexprs, _) ]) ->

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -268,6 +268,12 @@ module Quotations =
                 | NewUnionCase (uci, []) when uci.DeclaringType |> isGenericTypeDefinedFrom<option<_>> ->
                     BsonElement("$unset", BsonDocument(field, BsonInt32(1)))
 
+                | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
+                    BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
+
+                | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (|||) @> _)) ->
+                    BsonElement("$bit", BsonDocument(field, BsonDocument("or", BsonInt32(value))))
+
                 | _ -> failwith "unrecognized expression"
 
             | _ -> failwith "unrecognized pattern"

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -14,10 +14,13 @@ module Quotations =
     let private doc (elem : BsonElement) = BsonDocument(elem)
 
     let rec private parser v q =
-        let (|Dynamic|_|) expr =
+        let rec (|Dynamic|_|) expr =
             match expr with
             | SpecificCall <@ (?) @> (_, _, [ Var(var); String(field) ]) ->
                 Some(var, field)
+
+            | SpecificCall <@ (?) @> (_, _, [ Dynamic(var, subdoc); String(field) ]) ->
+                Some(var, sprintf "%s.%s" subdoc field)
 
             | _ -> None
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -83,6 +83,7 @@ module Quotations =
                 match args with
                 | [] -> Some([], typeof<unit>)
                 | [ Value (head, typ); List (tail, _) ] -> Some(head :: tail, typ)
+                | [ head; List (tail, _) ] -> Some(box head :: tail, typeof<Expr>)
                 | _ -> failwith "unexpected list union case"
 
             | _ -> None
@@ -128,6 +129,10 @@ module Quotations =
                 BsonElement(field, BsonDocument("$nin", BsonValue.Create value))
 
             | _ -> failwith "unrecognized expression"
+
+        | SpecificCall <@ Query.nor @> (_, _, [ List (subexprs, _) ]) ->
+            let subElems = subexprs |> List.map (fun q -> parser v (unbox q))
+            BsonElement("$nor", BsonArray(List.map (fun elem -> doc elem) subElems))
 
         | SpecificCall <@ not @> (_, _, [ inner ]) ->
             let innerElem = parser v inner

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -141,6 +141,11 @@ module Quotations =
             | Lambda(_, SpecificCall <@ Query.nexists @> _) ->
                 BsonElement(field, BsonDocument("$exists", BsonBoolean(false)))
 
+            | Let (_, Value(value, _), Lambda (_, SpecificCall <@ Query.type' @> _)) ->
+                match value with
+                | :? BsonType as typ -> BsonElement(field, BsonDocument("$type", BsonValue.Create typ))
+                | _ -> failwith "expected bson type"
+
             | _ -> failwith "unrecognized expression"
 
         | SpecificCall <@ Query.nor @> (_, _, [ List (subexprs, _) ]) ->

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -11,6 +11,52 @@ module Quotations =
     let (?) (doc : BsonDocument) (field : string) =
         unbox doc.[field]
 
+    let (?<-) (doc : BsonDocument) (field : string) value =
+        doc.[field] = unbox value |> ignore
+
+    let (=~) input pattern =
+        System.Text.RegularExpressions.Regex.IsMatch(input, pattern)
+
+    [<RequireQualifiedAccess>]
+    module Query =
+
+        let all (x : 'a list) (y : 'a list) : bool = invalidOp "not implemented"
+
+        let in' (x : 'a list) (y : 'a) : bool = invalidOp "not implemented"
+
+        let nin (x : 'a list) (y : 'a) : bool = invalidOp "not implemented"
+
+        let nor (x : bool list) : bool = invalidOp "not implemented"
+
+        let exists x : bool = invalidOp "not implemented"
+
+        let type' (x : BsonType) y : bool = invalidOp "not implemented"
+
+        let where (x : string) y : bool = invalidOp "not implemented"
+
+        let elemMatch x y : bool = invalidOp "not implemented"
+
+        let size (x : int) y : bool = invalidOp "not implemented"
+
+    [<RequireQualifiedAccess>]
+    module Update =
+
+        let addToSet (x : 'a) (y : 'a list) : 'a list = invalidOp "not implemented"
+
+        let popleft (x : 'a list) : 'a list = invalidOp "not implemented"
+
+        let popright (x : 'a list) : 'a list = invalidOp "not implemented"
+
+        let pullAll (x : 'a list) (y : 'a list) : 'a list = invalidOp "not implemented"
+
+        let push (x : 'a) (y : 'a list) : 'a list = invalidOp "not implemented"
+
+        let each (x : 'a -> 'a list -> 'a list) (y : 'a list) (z : 'a list) : 'a list = invalidOp "not implemented"
+
+        let slice (x : int) (y : 'a list) : 'a list = invalidOp "not implemented"
+
+        let sort (x : 'a) (y : 'b list) : 'b list = invalidOp "not implemented"
+
     let private doc (elem : BsonElement) = BsonDocument(elem)
 
     let rec private parser v q =

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -295,6 +295,16 @@ module Quotations =
                 | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.push @> _)) ->
                     BsonElement("$push", BsonDocument(field, BsonArray(values)))
 
+                | Let (_, op, Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.each @> _))) ->
+                    match op with
+                    | Lambda (_, Lambda (_, SpecificCall <@ Update.addToSet @> _)) ->
+                        BsonElement("$addToSet", BsonDocument(field, BsonDocument("$each", BsonArray(values))))
+
+                    | Lambda (_, Lambda (_, SpecificCall <@ Update.push @> _)) ->
+                        BsonElement("$push", BsonDocument(field, BsonDocument("$each", BsonArray(values))))
+
+                    | _ -> failwith "unrecognized operation with Update.each"
+
                 | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
                     BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -1,0 +1,66 @@
+namespace FSharp.MongoDB.Driver
+
+open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
+
+open MongoDB.Bson
+
+module Quotations =
+
+    let (=%) (field : string) value : bool = invalidOp "not implemented"
+
+    let (>%) (field : string) value : bool = invalidOp "not implemented"
+
+    let (<%) (field : string) value : bool = invalidOp "not implemented"
+
+    let private doc (elem : BsonElement) = BsonDocument(elem)
+
+    let rec private parser q =
+        match q with
+        | SpecificCall <@ (=%) @> (_, _, exprs) ->
+            match exprs with
+            | [ String(field); Value(value, _) ] ->
+                BsonElement(field, BsonValue.Create value)
+            | _ -> failwith "expected binary operation"
+
+        | SpecificCall <@ (>%) @> (_, _, exprs) ->
+            match exprs with
+            | [ String(field); Value(value, _) ] ->
+                BsonElement(field, BsonDocument("$gt", BsonValue.Create value))
+            | _ -> failwith "expected binary operation"
+
+        | SpecificCall <@ (<%) @> (_, _, exprs) ->
+            match exprs with
+            | [ String(field); Value(value, _) ] ->
+                BsonElement(field, BsonDocument("$lt", BsonValue.Create value))
+            | _ -> failwith "expected binary operation"
+
+        | AndAlso (lhs, rhs) ->
+            let lhsElem = parser lhs
+            let rhsElem = parser rhs
+
+            if lhsElem.Name = "$and" then
+                match lhsElem.Value with
+                | :? BsonArray as value ->
+                    value.Add(doc rhsElem) |> ignore
+                    lhsElem
+                | _ -> failwith "expected bson array"
+
+            else BsonElement("$and", BsonArray([ doc lhsElem; doc rhsElem ]))
+
+        | OrElse (lhs, rhs) ->
+            let lhsElem = parser lhs
+            let rhsElem = parser rhs
+
+            if lhsElem.Name = "$or" then
+                match lhsElem.Value with
+                | :? BsonArray as value ->
+                    value.Add(BsonDocument(parser rhs)) |> ignore
+                    lhsElem
+                | _ -> failwith "expected bson array"
+
+            else BsonElement("$or", BsonArray([ doc lhsElem; doc rhsElem ]))
+
+        | _ -> invalidOp "unrecognized pattern"
+
+    let bson q = BsonDocument(parser q)

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -289,6 +289,12 @@ module Quotations =
                 | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.pullAll @> _)) ->
                     BsonElement("$pullAll", BsonDocument(field, BsonArray(values)))
 
+                | Let (_, Value (value, _), Lambda (_, SpecificCall <@ Update.push @> _)) ->
+                    BsonElement("$push", BsonDocument(field, BsonValue.Create value))
+
+                | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.push @> _)) ->
+                    BsonElement("$push", BsonDocument(field, BsonArray(values)))
+
                 | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
                     BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -44,6 +44,10 @@ module Quotations =
     [<RequireQualifiedAccess>]
     module Update =
 
+        let rename (x : (string * string) list) (y : 'a) : 'a = invalidOp "not implemented"
+
+        let setOnInsert (x : unit list) (y : 'a) : 'a = invalidOp "not implemented"
+
         let addToSet (x : 'a) (y : 'a list) : 'a list = invalidOp "not implemented"
 
         let popleft (x : 'a list) : 'a list = invalidOp "not implemented"

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -54,6 +54,8 @@ module Quotations =
 
         let popright (x : 'a list) : 'a list = invalidOp "not implemented"
 
+        let pull (x : 'a) (y : 'b list) : 'b list = invalidOp "not implemented"
+
         let pullAll (x : 'a list) (y : 'a list) : 'a list = invalidOp "not implemented"
 
         let push (x : 'a) (y : 'a list) : 'a list = invalidOp "not implemented"

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -121,6 +121,12 @@ module Quotations =
             | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.all @> _)) ->
                 BsonElement(field, BsonDocument("$all", BsonValue.Create value))
 
+            | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.in' @> _)) ->
+                BsonElement(field, BsonDocument("$in", BsonValue.Create value))
+
+            | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.nin @> _)) ->
+                BsonElement(field, BsonDocument("$nin", BsonValue.Create value))
+
             | _ -> failwith "unrecognized expression"
 
         | AndAlso (lhs, rhs) ->

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -101,6 +101,11 @@ module Quotations =
             | _ -> None
 
         match q with
+        | SpecificCall <@ (=) @> (_, _, [ SpecificCall <@ (%) @> (_, _, [ Dynamic(var, field)
+                                                                          Value(divisor, _) ])
+                                          Value(remainder, _) ]) when var = v ->
+            BsonElement(field, BsonDocument("$mod", BsonArray([ divisor; remainder ])))
+
         | Comparison <@ (=) @> (field, value) ->
             BsonElement(field, BsonValue.Create value)
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -282,6 +282,13 @@ module Quotations =
                 | Lambda (_, SpecificCall <@ Update.popright @> _) ->
                     BsonElement("$pop", BsonDocument(field, BsonInt32(1)))
 
+                | Let (_, SpecificCall <@ bson @> (_, _, [ Quote (Lambda (v, q)) ]), Lambda (_, SpecificCall <@ Update.pull @> _)) ->
+                    let nestedElem = queryParser v q
+                    BsonElement("$pull", BsonDocument(field, doc nestedElem))
+
+                | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.pullAll @> _)) ->
+                    BsonElement("$pullAll", BsonDocument(field, BsonArray(values)))
+
                 | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
                     BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -124,6 +124,13 @@ module Quotations =
         | Comparison <@ (<=) @> (field, value) ->
             BsonElement(field, BsonDocument("$lte", BsonValue.Create value))
 
+        | SpecificCall <@ (=~) @> (_, _, [ Dynamic(var, field); String(pcre) ]) when var = v ->
+            let index = pcre.LastIndexOf('/')
+            let regex = pcre.Substring(1, index - 1)
+            let options = pcre.Substring(index + 1)
+            BsonElement(field, BsonDocument([ BsonElement("$regex", BsonString(regex))
+                                              BsonElement("$options", BsonString(options)) ]))
+
         | SpecificCall <@ (|>) @> (_, _, [ Var(var)
                                            Let (_, String(js), Lambda (_, SpecificCall <@ Query.where @> _)) ]) when var = v ->
             BsonElement("$where", BsonString(js))

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -276,6 +276,12 @@ module Quotations =
                 | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.addToSet @> _)) ->
                     BsonElement("$addToSet", BsonDocument(field, BsonArray(values)))
 
+                | Lambda (_, SpecificCall <@ Update.popleft @> _) ->
+                    BsonElement("$pop", BsonDocument(field, BsonInt32(-1)))
+
+                | Lambda (_, SpecificCall <@ Update.popright @> _) ->
+                    BsonElement("$pop", BsonDocument(field, BsonInt32(1)))
+
                 | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
                     BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -124,6 +124,10 @@ module Quotations =
         | Comparison <@ (<=) @> (field, value) ->
             BsonElement(field, BsonDocument("$lte", BsonValue.Create value))
 
+        | SpecificCall <@ (|>) @> (_, _, [ Var(var)
+                                           Let (_, String(js), Lambda (_, SpecificCall <@ Query.where @> _)) ]) when var = v ->
+            BsonElement("$where", BsonString(js))
+
         | SpecificCall <@ (|>) @> (_, _, [ Dynamic(var, field); subexpr ]) when var = v ->
             match subexpr with
             | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.all @> _)) ->

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -129,6 +129,11 @@ module Quotations =
 
             | _ -> failwith "unrecognized expression"
 
+        | SpecificCall <@ not @> (_, _, [ inner ]) ->
+            let innerElem = parser v inner
+            innerElem.Value <- doc <| BsonElement("$not", innerElem.Value)
+            innerElem
+
         | AndAlso (lhs, rhs) ->
             let lhsElem = parser v lhs
             let rhsElem = parser v rhs

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -31,6 +31,8 @@ module Quotations =
 
         let exists x : bool = invalidOp "not implemented"
 
+        let nexists x : bool = invalidOp "not implemented"
+
         let type' (x : BsonType) y : bool = invalidOp "not implemented"
 
         let where (x : string) y : bool = invalidOp "not implemented"
@@ -127,6 +129,12 @@ module Quotations =
 
             | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.nin @> _)) ->
                 BsonElement(field, BsonDocument("$nin", BsonValue.Create value))
+
+            | Lambda(_, SpecificCall <@ Query.exists @> _) ->
+                BsonElement(field, BsonDocument("$exists", BsonBoolean(true)))
+
+            | Lambda(_, SpecificCall <@ Query.nexists @> _) ->
+                BsonElement(field, BsonDocument("$exists", BsonBoolean(false)))
 
             | _ -> failwith "unrecognized expression"
 

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -116,6 +116,13 @@ module Quotations =
         | Comparison <@ (<=) @> (field, value) ->
             BsonElement(field, BsonDocument("$lte", BsonValue.Create value))
 
+        | SpecificCall <@ (|>) @> (_, _, [ Dynamic(var, field); subexpr ]) when var = v ->
+            match subexpr with
+            | Let (_, List (value, _), Lambda (_, SpecificCall <@ Query.all @> _)) ->
+                BsonElement(field, BsonDocument("$all", BsonValue.Create value))
+
+            | _ -> failwith "unrecognized expression"
+
         | AndAlso (lhs, rhs) ->
             let lhsElem = parser v lhs
             let rhsElem = parser v rhs

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -259,6 +259,15 @@ module Quotations =
                 | Let (_, Int32(value), Lambda (_, SpecificCall <@ (-) @> _)) ->
                     BsonElement("$inc", BsonDocument(field, BsonInt32(-value)))
 
+                | Value (value, _) ->
+                    BsonElement("$set", BsonDocument(field, BsonValue.Create value))
+
+                | List (values, _) ->
+                    BsonElement("$set", BsonDocument(field, BsonArray(values)))
+
+                | NewUnionCase (uci, []) when uci.DeclaringType |> isGenericTypeDefinedFrom<option<_>> ->
+                    BsonElement("$unset", BsonDocument(field, BsonInt32(1)))
+
                 | _ -> failwith "unrecognized expression"
 
             | _ -> failwith "unrecognized pattern"

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -270,6 +270,12 @@ module Quotations =
                 | NewUnionCase (uci, []) when uci.DeclaringType |> isGenericTypeDefinedFrom<option<_>> ->
                     BsonElement("$unset", BsonDocument(field, BsonInt32(1)))
 
+                | Let (_, Value (value, _), Lambda (_, SpecificCall <@ Update.addToSet @> _)) ->
+                    BsonElement("$addToSet", BsonDocument(field, BsonValue.Create value))
+
+                | Let (_, List (values, _), Lambda (_, SpecificCall <@ Update.addToSet @> _)) ->
+                    BsonElement("$addToSet", BsonDocument(field, BsonArray(values)))
+
                 | Let (_, Int32 (value), Lambda (_, SpecificCall <@ (&&&) @> _)) ->
                     BsonElement("$bit", BsonDocument(field, BsonDocument("and", BsonInt32(value))))
 

--- a/src/FSharp.MongoDB.Driver/Serialization/FSharpTypeSerializer.fs
+++ b/src/FSharp.MongoDB.Driver/Serialization/FSharpTypeSerializer.fs
@@ -1,0 +1,52 @@
+namespace FSharp.MongoDB.Driver
+
+open Microsoft.FSharp.Reflection
+
+open MongoDB.Bson
+open MongoDB.Bson.Serialization
+open MongoDB.Bson.Serialization.Serializers
+
+module Serialization =
+
+    [<RequireQualifiedAccess>]
+    module FSharpTypeSerializer =
+
+        [<AutoOpen>]
+        module private Bson =
+
+            type RecordTypeSerializer(typ : System.Type) =
+                inherit BsonBaseSerializer()
+
+                let fields =
+                    FSharpType.GetRecordFields(typ)
+                    |> Seq.map (fun (x : System.Reflection.PropertyInfo) -> x.Name)
+
+                override __.Serialize(writer, nominalType, value, options) =
+                    let values = FSharpValue.GetRecordFields(value)
+
+                    writer.WriteStartDocument()
+
+                    Seq.iter2 (fun field value ->
+                        writer.WriteName(field)
+                        BsonSerializer.Serialize(writer, value)
+                    ) fields values
+
+                    writer.WriteEndDocument()
+
+                override __.Deserialize(reader, nominalType, actualType, options) =
+                    invalidOp "not implemented"
+
+            type FSharpTypeSerializationProvider() =
+
+                interface IBsonSerializationProvider with
+                    member __.GetSerializer(typ : System.Type) =
+                        if FSharpType.IsRecord(typ) then
+                            RecordTypeSerializer(typ) :> IBsonSerializer
+                        else null
+
+        let mutable private registered = false
+
+        let register() =
+            if not registered then
+                registered <- true
+                BsonSerializer.RegisterSerializationProvider(FSharpTypeSerializationProvider())

--- a/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
+++ b/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
@@ -61,6 +61,9 @@
     <Compile Include="MongoBackboneTests.fs">
       <Link>MongoBackboneTests.fs</Link>
     </Compile>
+    <Compile Include="QuotableMongoTests.fs">
+      <Link>QuotableMongoTests.fs</Link>
+    </Compile>
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>

--- a/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
+++ b/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
@@ -64,6 +64,9 @@
     <Compile Include="QuotableMongoTests.fs">
       <Link>QuotableMongoTests.fs</Link>
     </Compile>
+    <Compile Include="TypedQuotableMongoTests.fs">
+      <Link>TypedQuotableMongoTests.fs</Link>
+    </Compile>
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -201,3 +201,24 @@ module QuotableMongo =
                 let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(-2))) @>
 
                 test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test set``() =
+                let query = <@ <@ fun x -> [ x?qty <- 20 ] @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test set list``() =
+                let query = <@ <@ fun x -> [ x?tags <- [ "appliances"; "school"; "book" ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unset``() =
+                let query = <@ <@ fun x -> [ x?qty <- None ] @> |> bson @>
+                let expected = <@ BsonDocument("$unset", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -111,3 +111,22 @@ module QuotableMongo =
             let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>
 
             test <@ %query = %expected @>
+
+[<TestFixture>]
+module Element =
+
+    [<Test>]
+    let ``test exists``() =
+        let query = <@ <@ fun x -> x?qty |> Query.exists && x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
+        let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(true)))
+                                                           BsonDocument("qty", BsonDocument("$nin", BsonArray([ 5; 15 ]))) ])) @>
+
+        test <@ %query = %expected @>
+
+    [<Test>]
+    let ``test not exists``() =
+        let query = <@ <@ fun x -> x?qty |> Query.nexists || x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
+        let expected = <@ BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(false)))
+                                                          BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) ])) @>
+
+        test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -164,3 +164,21 @@ module QuotableMongo =
                                                                        BsonElement("$options", BsonString("i")) ])) @>
 
                 test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module Array =
+
+            [<Test>]
+            let ``test element match``() =
+                let query = <@ <@ fun x -> x?array |> Query.elemMatch (bson <@ fun y -> y?value1 = 1 && y?value2 > 1 @>) @> |> bson @>
+                let expected = <@ BsonDocument("array", BsonDocument("$elemMatch", BsonDocument([ BsonElement("value1", BsonInt32(1))
+                                                                                                  BsonElement("value2", BsonDocument("$gt", BsonInt32(1))) ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test size``() =
+                let query = <@ <@ fun x -> x?field |> Query.size 2 @> |> bson @>
+                let expected = <@ BsonDocument("field", BsonDocument("$size", BsonInt32(2))) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -95,3 +95,10 @@ module QuotableMongo =
                                                                                                BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
 
             test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test not``() =
+            let query = <@ <@ fun x -> not (x?price > 1.99) @> |> bson @>
+            let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>
+
+            test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -124,6 +124,13 @@ module Element =
         test <@ %query = %expected @>
 
     [<Test>]
+    let ``test mod``() =
+        let query = <@ <@ fun x -> x?qty % 4 = 0 @> |> bson @>
+        let expected = <@ BsonDocument("qty", BsonDocument("$mod", BsonArray([4; 0]))) @>
+
+        test <@ %query = %expected @>
+
+    [<Test>]
     let ``test not exists``() =
         let query = <@ <@ fun x -> x?qty |> Query.nexists || x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
         let expected = <@ BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(false)))

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -203,6 +203,14 @@ module QuotableMongo =
                 test <@ %query = %expected @>
 
             [<Test>]
+            let ``test rename``() =
+                let query = <@ <@ fun x -> [ x |> Update.rename [ ("nickname", "alias"); ("cell", "mobile") ] |> ignore ] @> |> bson @>
+                let expected = <@ BsonDocument("$rename", BsonDocument([ BsonElement("nickname", BsonString("alias"))
+                                                                         BsonElement("cell", BsonString("mobile")) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
             let ``test set``() =
                 let query = <@ <@ fun x -> [ x?qty <- 20 ] @> |> bson @>
                 let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -13,6 +13,13 @@ module QuotableMongo =
     module Comparison =
 
         [<Test>]
+        let ``test all``() =
+            let query = <@ <@ fun x -> x?tags |> Query.all [ "appliances"; "school"; "book" ] @> |> bson @>
+            let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
         let ``test equal to``() =
             let query = <@ <@ fun x -> x?qty = 20 @> |> bson @>
             let expected = <@ BsonDocument("qty", BsonInt32(20)) @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -182,3 +182,22 @@ module QuotableMongo =
                 let expected = <@ BsonDocument("field", BsonDocument("$size", BsonInt32(2))) @>
 
                 test <@ %query = %expected @>
+
+    module Update =
+
+        [<TestFixture>]
+        module Fields =
+
+            [<Test>]
+            let ``test increment``() =
+                let query = <@ <@ fun x -> [ x?age <- (+) 1 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test decrement``() =
+                let query = <@ <@ fun x -> [ x?age <- (-) 2 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(-2))) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -297,22 +297,15 @@ module QuotableMongo =
 
                 test <@ %query = %expected @>
 
-            type private Quiz = {
-                Id : int
-                Score : int
-            }
-
             [<Test>]
             let ``test push with sort modifier``() =
-                let query = <@ <@ fun (x : BsonDocument) -> [ x?quizzes <- Update.each Update.push [ { Id = 3; Score = 8 }
-                                                                                                     { Id = 4; Score = 7 }
-                                                                                                     { Id = 5; Score = 6 } ]
-                                                                        >> Update.sort (bson <@ fun (y : BsonDocument) -> y?score = 1 @>)
-                                                                        >> Update.slice -5 ] @> |> bson @>
-
                 let quiz3 = BsonDocument([ BsonElement("id", BsonInt32(3)); BsonElement("score", BsonInt32(8)) ])
                 let quiz4 = BsonDocument([ BsonElement("id", BsonInt32(4)); BsonElement("score", BsonInt32(7)) ])
                 let quiz5 = BsonDocument([ BsonElement("id", BsonInt32(5)); BsonElement("score", BsonInt32(6)) ])
+
+                let query = <@ <@ fun (x : BsonDocument) -> [ x?quizzes <- Update.each Update.push [ quiz3; quiz4; quiz5 ]
+                                                                        >> Update.sort (bson <@ fun (y : BsonDocument) -> y?score = 1 @>)
+                                                                        >> Update.slice -5 ] @> |> bson @>
 
                 let expected =
                     <@ BsonDocument("$push", BsonDocument("quizzes", BsonDocument([ BsonElement("$each", BsonArray([ quiz3; quiz4; quiz5 ]))

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -9,156 +9,158 @@ open FSharp.MongoDB.Driver.Quotations
 
 module QuotableMongo =
 
-    [<TestFixture>]
-    module Comparison =
+    module Query =
 
-        [<Test>]
-        let ``test all``() =
-            let query = <@ <@ fun x -> x?tags |> Query.all [ "appliances"; "school"; "book" ] @> |> bson @>
-            let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
+        [<TestFixture>]
+        module Comparison =
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test all``() =
+                let query = <@ <@ fun x -> x?tags |> Query.all [ "appliances"; "school"; "book" ] @> |> bson @>
+                let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
 
-        [<Test>]
-        let ``test equal to``() =
-            let query = <@ <@ fun x -> x?qty = 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonInt32(20)) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test equal to``() =
+                let query = <@ <@ fun x -> x?qty = 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonInt32(20)) @>
 
-        [<Test>]
-        let ``test greater than``() =
-            let query = <@ <@ fun x -> x?qty > 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$gt", BsonInt32(20))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test greater than``() =
+                let query = <@ <@ fun x -> x?qty > 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$gt", BsonInt32(20))) @>
 
-        [<Test>]
-        let ``test greater than or equal to``() =
-            let query = <@ <@ fun x -> x?qty >= 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$gte", BsonInt32(20))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test greater than or equal to``() =
+                let query = <@ <@ fun x -> x?qty >= 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$gte", BsonInt32(20))) @>
 
-        [<Test>]
-        let ``test in``() =
-            let query = <@ <@ fun x -> x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test in``() =
+                let query = <@ <@ fun x -> x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) @>
 
-        [<Test>]
-        let ``test less than``() =
-            let query = <@ <@ fun x -> x?qty < 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test less than``() =
+                let query = <@ <@ fun x -> x?qty < 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20))) @>
 
-        [<Test>]
-        let ``test less than or equal to``() =
-            let query = <@ <@ fun x -> x?qty <= 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$lte", BsonInt32(20))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test less than or equal to``() =
+                let query = <@ <@ fun x -> x?qty <= 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$lte", BsonInt32(20))) @>
 
-        [<Test>]
-        let ``test not equal to``() =
-            let query = <@ <@ fun x -> x?qty <> 20 @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test not equal to``() =
+                let query = <@ <@ fun x -> x?qty <> 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
 
-        [<Test>]
-        let ``test not in``() =
-            let query = <@ <@ fun x -> x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
-            let expected = <@ BsonDocument("qty", BsonDocument("$nin", BsonArray([5; 15]))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test not in``() =
+                let query = <@ <@ fun x -> x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$nin", BsonArray([5; 15]))) @>
 
-    [<TestFixture>]
-    module Logical =
+                test <@ %query = %expected @>
 
-        [<Test>]
-        let ``test and``() =
-            let query = <@ <@ fun x -> x?price = 1.99 && x?qty < 20 && x?sale = true @> |> bson @>
-            let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
-                                                               BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
-                                                               BsonDocument("sale", BsonBoolean(true)) ])) @>
+        [<TestFixture>]
+        module Logical =
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test and``() =
+                let query = <@ <@ fun x -> x?price = 1.99 && x?qty < 20 && x?sale = true @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                   BsonDocument("sale", BsonBoolean(true)) ])) @>
 
-        [<Test>]
-        let ``test or``() =
-            let query = <@ <@ fun x -> x?price = 1.99 && (x?qty < 20 || x?sale = true) @> |> bson @>
-            let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
-                                                               BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
-                                                                                               BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test or``() =
+                let query = <@ <@ fun x -> x?price = 1.99 && (x?qty < 20 || x?sale = true) @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                                                   BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
 
-        [<Test>]
-        let ``test nor``() =
-            let query = <@ <@ fun x -> Query.nor [ x?price = 1.99; x?qty < 20; x?sale = true ] @> |> bson @>
-            let expected = <@ BsonDocument("$nor", BsonArray([ BsonDocument("price", BsonDouble(1.99))
-                                                               BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
-                                                               BsonDocument("sale", BsonBoolean(true)) ])) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test nor``() =
+                let query = <@ <@ fun x -> Query.nor [ x?price = 1.99; x?qty < 20; x?sale = true ] @> |> bson @>
+                let expected = <@ BsonDocument("$nor", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                   BsonDocument("sale", BsonBoolean(true)) ])) @>
 
-        [<Test>]
-        let ``test not``() =
-            let query = <@ <@ fun x -> not (x?price > 1.99) @> |> bson @>
-            let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>
+                test <@ %query = %expected @>
 
-            test <@ %query = %expected @>
+            [<Test>]
+            let ``test not``() =
+                let query = <@ <@ fun x -> not (x?price > 1.99) @> |> bson @>
+                let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>
 
-[<TestFixture>]
-module Element =
+                test <@ %query = %expected @>
 
-    [<Test>]
-    let ``test exists``() =
-        let query = <@ <@ fun x -> x?qty |> Query.exists && x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
-        let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(true)))
-                                                           BsonDocument("qty", BsonDocument("$nin", BsonArray([ 5; 15 ]))) ])) @>
+        [<TestFixture>]
+        module Element =
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test exists``() =
+                let query = <@ <@ fun x -> x?qty |> Query.exists && x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(true)))
+                                                                   BsonDocument("qty", BsonDocument("$nin", BsonArray([ 5; 15 ]))) ])) @>
 
-    [<Test>]
-    let ``test mod``() =
-        let query = <@ <@ fun x -> x?qty % 4 = 0 @> |> bson @>
-        let expected = <@ BsonDocument("qty", BsonDocument("$mod", BsonArray([4; 0]))) @>
+                test <@ %query = %expected @>
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test mod``() =
+                let query = <@ <@ fun x -> x?qty % 4 = 0 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$mod", BsonArray([4; 0]))) @>
 
-    [<Test>]
-    let ``test not exists``() =
-        let query = <@ <@ fun x -> x?qty |> Query.nexists || x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
-        let expected = <@ BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(false)))
-                                                          BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) ])) @>
+                test <@ %query = %expected @>
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test not exists``() =
+                let query = <@ <@ fun x -> x?qty |> Query.nexists || x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(false)))
+                                                                  BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) ])) @>
 
-    [<Test>]
-    let ``test type``() =
-        let query = <@ <@ fun x -> x?price |> Query.type' BsonType.Double @> |> bson @>
-        let expected = <@ BsonDocument("price", BsonDocument("$type", BsonInt32(1))) @>
+                test <@ %query = %expected @>
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test type``() =
+                let query = <@ <@ fun x -> x?price |> Query.type' BsonType.Double @> |> bson @>
+                let expected = <@ BsonDocument("price", BsonDocument("$type", BsonInt32(1))) @>
 
-[<TestFixture>]
-module JavaScript =
+                test <@ %query = %expected @>
 
-    [<Test>]
-    let ``test where``() =
-        let query = <@ <@ fun x -> x |> Query.where "this.credits == this.debits" @> |> bson @>
-        let expected = <@ BsonDocument("$where", BsonString("this.credits == this.debits")) @>
+        [<TestFixture>]
+        module JavaScript =
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test where``() =
+                let query = <@ <@ fun x -> x |> Query.where "this.credits == this.debits" @> |> bson @>
+                let expected = <@ BsonDocument("$where", BsonString("this.credits == this.debits")) @>
 
-    [<Test>]
-    let ``test regex``() =
-        let query = <@ <@ fun x -> x?field =~ "/acme.*corp/i" @> |> bson @>
-        let expected = <@ BsonDocument("field", BsonDocument([ BsonElement("$regex", BsonString("acme.*corp"))
-                                                               BsonElement("$options", BsonString("i")) ])) @>
+                test <@ %query = %expected @>
 
-        test <@ %query = %expected @>
+            [<Test>]
+            let ``test regex``() =
+                let query = <@ <@ fun x -> x?field =~ "/acme.*corp/i" @> |> bson @>
+                let expected = <@ BsonDocument("field", BsonDocument([ BsonElement("$regex", BsonString("acme.*corp"))
+                                                                       BsonElement("$options", BsonString("i")) ])) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -137,3 +137,10 @@ module Element =
                                                           BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) ])) @>
 
         test <@ %query = %expected @>
+
+    [<Test>]
+    let ``test type``() =
+        let query = <@ <@ fun x -> x?price |> Query.type' BsonType.Double @> |> bson @>
+        let expected = <@ BsonDocument("price", BsonDocument("$type", BsonInt32(1))) @>
+
+        test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -41,6 +41,13 @@ module QuotableMongo =
             test <@ %query = %expected @>
 
         [<Test>]
+        let ``test in``() =
+            let query = <@ <@ fun x -> x?qty |> Query.in' [ 5; 15 ] @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
         let ``test less than``() =
             let query = <@ <@ fun x -> x?qty < 20 @> |> bson @>
             let expected = <@ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20))) @>
@@ -58,6 +65,13 @@ module QuotableMongo =
         let ``test not equal to``() =
             let query = <@ <@ fun x -> x?qty <> 20 @> |> bson @>
             let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test not in``() =
+            let query = <@ <@ fun x -> x?qty |> Query.nin [ 5; 15 ] @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$nin", BsonArray([5; 15]))) @>
 
             test <@ %query = %expected @>
 

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -1,0 +1,55 @@
+namespace FSharp.MongoDB.Driver.Tests
+
+open MongoDB.Bson
+
+open NUnit.Framework
+open Swensen.Unquote
+
+open FSharp.MongoDB.Driver.Quotations
+
+module QuotableMongo =
+
+    [<TestFixture>]
+    module Comparison =
+
+        [<Test>]
+        let ``test equal to``() =
+            let query = <@ <@ fun x -> x?qty = 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonInt32(20)) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test greater than``() =
+            let query = <@ <@ fun x -> x?qty > 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$gt", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test greater than or equal to``() =
+            let query = <@ <@ fun x -> x?qty >= 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$gte", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test less than``() =
+            let query = <@ <@ fun x -> x?qty < 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test less than or equal to``() =
+            let query = <@ <@ fun x -> x?qty <= 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$lte", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test not equal to``() =
+            let query = <@ <@ fun x -> x?qty <> 20 @> |> bson @>
+            let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
+
+            test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -222,3 +222,20 @@ module QuotableMongo =
                 let expected = <@ BsonDocument("$unset", BsonDocument("qty", BsonInt32(1))) @>
 
                 test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module Bitwise =
+
+            [<Test>]
+            let ``test bitwise and``() =
+                let query = <@ <@ fun x -> [ x?field <- (&&&) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test bitwise or``() =
+                let query = <@ <@ fun x -> [ x?field <- (|||) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -97,6 +97,15 @@ module QuotableMongo =
             test <@ %query = %expected @>
 
         [<Test>]
+        let ``test nor``() =
+            let query = <@ <@ fun x -> Query.nor [ x?price = 1.99; x?qty < 20; x?sale = true ] @> |> bson @>
+            let expected = <@ BsonDocument("$nor", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                               BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                               BsonDocument("sale", BsonBoolean(true)) ])) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
         let ``test not``() =
             let query = <@ <@ fun x -> not (x?price > 1.99) @> |> bson @>
             let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -154,3 +154,11 @@ module JavaScript =
         let expected = <@ BsonDocument("$where", BsonString("this.credits == this.debits")) @>
 
         test <@ %query = %expected @>
+
+    [<Test>]
+    let ``test regex``() =
+        let query = <@ <@ fun x -> x?field =~ "/acme.*corp/i" @> |> bson @>
+        let expected = <@ BsonDocument("field", BsonDocument([ BsonElement("$regex", BsonString("acme.*corp"))
+                                                               BsonElement("$options", BsonString("i")) ])) @>
+
+        test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -53,3 +53,24 @@ module QuotableMongo =
             let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
 
             test <@ %query = %expected @>
+
+    [<TestFixture>]
+    module Logical =
+
+        [<Test>]
+        let ``test and``() =
+            let query = <@ <@ fun x -> x?price = 1.99 && x?qty < 20 && x?sale = true @> |> bson @>
+            let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                               BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                               BsonDocument("sale", BsonBoolean(true)) ])) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test or``() =
+            let query = <@ <@ fun x -> x?price = 1.99 && (x?qty < 20 || x?sale = true) @> |> bson @>
+            let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                               BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                                               BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
+
+            test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -144,3 +144,13 @@ module Element =
         let expected = <@ BsonDocument("price", BsonDocument("$type", BsonInt32(1))) @>
 
         test <@ %query = %expected @>
+
+[<TestFixture>]
+module JavaScript =
+
+    [<Test>]
+    let ``test where``() =
+        let query = <@ <@ fun x -> x |> Query.where "this.credits == this.debits" @> |> bson @>
+        let expected = <@ BsonDocument("$where", BsonString("this.credits == this.debits")) @>
+
+        test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
@@ -264,3 +264,332 @@ module TypedQuotableMongo =
             let expected = <@ BsonDocument("other.duration", BsonInt32(45)) @>
 
             test <@ %query = %expected @>
+
+    module Update =
+
+        [<TestFixture>]
+        module Fields =
+
+            [<Test>]
+            let ``test typed mutable increment``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty |> (+) 1 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable increment infix``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty + 1 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable increment``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty |> (+) 1 } @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable increment infix``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty + 1 } @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable decrement``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty |> (-) 2 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable decrement infix``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty - 2 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable decrement``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty |> (-) 2 } @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable decrement infix``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty - 2 } @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable set``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- 20 ] @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable set``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = 20 } @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable set list``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- [ "appliances"; "school"; "book" ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable set list``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = [ "appliances"; "school"; "book" ] } @> |> bson @>
+                let expected = <@ BsonDocument("$set", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable unset``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.option <- None ] @> |> bson @>
+                let expected = <@ BsonDocument("$unset", BsonDocument("option", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable unset``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with option = None } @> |> bson @>
+                let expected = <@ BsonDocument("$unset", BsonDocument("option", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+        [<TestFixture>]
+        module Array =
+
+            [<Test>]
+            let ``test typed mutable add to set``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.addToSet "toaster" ] @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@  %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable add to set``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.addToSet "toaster" } @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@  %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable pop left``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.sizes <- x.sizes |> Update.popleft ] @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(-1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable pop left``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with sizes = x.sizes |> Update.popleft } @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(-1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable pop right``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.sizes <- x.sizes |> Update.popright ] @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable pop right``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with sizes = x.sizes |> Update.popright } @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable pull``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.sizes <- x.sizes |> Update.pull (bson <@ fun (y : Mutable.Size) -> y.height = 75 @>) ] @> |> bson @>
+                let expected = <@ BsonDocument("$pull", BsonDocument("sizes", BsonDocument("height", BsonInt32(75)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable pull``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with sizes = x.sizes |> Update.pull (bson <@ fun (y : Immutable.Size) -> y.height = 75 @>) } @> |> bson @>
+                let expected = <@ BsonDocument("$pull", BsonDocument("sizes", BsonDocument("height", BsonInt32(75)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable pull all``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.pullAll [ "appliances"; "school"; "book" ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$pullAll", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable pull all``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.pullAll [ "appliances"; "school"; "book" ] } @> |> bson @>
+                let expected = <@ BsonDocument("$pullAll", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable push``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.push "toaster" ] @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable push``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.push "toaster" } @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable add to set with each modifier``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.each Update.addToSet [ "appliances"; "school"; "book" ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable add to set with each modifier``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.each Update.addToSet [ "appliances"; "school"; "book" ] } @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable push with each modifier``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.each Update.push [ "appliances"; "school"; "book" ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable push with each modifier``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.each Update.push [ "appliances"; "school"; "book" ] } @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable push with slice modifier``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.tags <- x.tags |> Update.each Update.push [ "appliances"; "school"; "book" ]
+                                                                                |> Update.slice -5 ] @> |> bson @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument([ BsonElement("$each", BsonArray([ "appliances"; "school"; "book" ]))
+                                                                                            BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable push with slice modifier``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with tags = x.tags |> Update.each Update.push [ "appliances"; "school"; "book" ]
+                                                                                      |> Update.slice -5 } @> |> bson @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument([ BsonElement("$each", BsonArray([ "appliances"; "school"; "book" ]))
+                                                                                            BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable push with sort modifier``() =
+                let size1 = { Mutable.Size.length = 3; Mutable.Size.width = 8; Mutable.Size.height = 1 }
+                let size2 = { Mutable.Size.length = 4; Mutable.Size.width = 7; Mutable.Size.height = 2 }
+                let size3 = { Mutable.Size.length = 5; Mutable.Size.width = 6; Mutable.Size.height = 4 }
+
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.sizes <- x.sizes |> Update.each Update.push [ size1; size2; size3 ]
+                                                                                  |> Update.sort (bson <@ fun (y : BsonDocument) -> y?width = 1 @>)
+                                                                                  |> Update.slice -5 ] @> |> bson @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ]))
+                                                                                             BsonElement("$sort", BsonDocument("width", BsonInt32(1)))
+                                                                                             BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable push with sort modifier``() =
+                let size1 = { Immutable.Size.length = 3; Immutable.Size.width = 8; Immutable.Size.height = 1 }
+                let size2 = { Immutable.Size.length = 4; Immutable.Size.width = 7; Immutable.Size.height = 2 }
+                let size3 = { Immutable.Size.length = 5; Immutable.Size.width = 6; Immutable.Size.height = 4 }
+
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with sizes = x.sizes |> Update.each Update.push [ size1; size2; size3 ]
+                                                                                        |> Update.sort (bson <@ fun (y : BsonDocument) -> y?width = 1 @>)
+                                                                                        |> Update.slice -5 } @> |> bson @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ]))
+                                                                                             BsonElement("$sort", BsonDocument("width", BsonInt32(1)))
+                                                                                             BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
+        [<TestFixture>]
+        module Bitwise =
+
+            [<Test>]
+            let ``test typed mutable bitwise and``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty |> (&&&) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable bitwise and infix``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty &&& 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable bitwise and``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty |> (&&&) 5 } @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable bitwise and infix``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty &&& 5 } @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable bitwise or``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty |> (|||) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mutable bitwise or infix``() =
+                let update = <@ <@ fun (x : Mutable.Item) -> [ x.qty <- x.qty ||| 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable bitwise or``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty |> (|||) 5 } @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed immutable bitwise or infix``() =
+                let update = <@ <@ fun (x : Immutable.Item) -> { x with qty = x.qty ||| 5 } @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
@@ -513,7 +513,9 @@ module TypedQuotableMongo =
                                                                                   |> Update.sort (bson <@ fun (y : BsonDocument) -> y?width = 1 @>)
                                                                                   |> Update.slice -5 ] @> |> bson @>
 
-                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ]))
+                let doc (x : Mutable.Size) = (box x).ToBsonDocument(x.GetType())
+
+                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ] |> List.map doc))
                                                                                              BsonElement("$sort", BsonDocument("width", BsonInt32(1)))
                                                                                              BsonElement("$slice", BsonInt32(-5)) ]))) @>
 
@@ -529,7 +531,9 @@ module TypedQuotableMongo =
                                                                                         |> Update.sort (bson <@ fun (y : BsonDocument) -> y?width = 1 @>)
                                                                                         |> Update.slice -5 } @> |> bson @>
 
-                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ]))
+                let doc (x : Immutable.Size)  = (box x).ToBsonDocument(x.GetType())
+
+                let expected = <@ BsonDocument("$push", BsonDocument("sizes", BsonDocument([ BsonElement("$each", BsonArray([ size1; size2; size3 ] |> List.map doc))
                                                                                              BsonElement("$sort", BsonDocument("width", BsonInt32(1)))
                                                                                              BsonElement("$slice", BsonInt32(-5)) ]))) @>
 

--- a/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
@@ -9,34 +9,247 @@ open FSharp.MongoDB.Driver.Quotations
 
 module TypedQuotableMongo =
 
-    [<TestFixture>]
-    module Query =
+    [<RequireQualifiedAccess>]
+    module Mutable =
 
         type Item = {
-            price : double
-            qty : int
-            sale : bool
+            mutable tags : string list
+            mutable qty : int
+            mutable price : float
+            mutable sale : bool
+            mutable desc : Desc
+            mutable sizes : Size list
+            mutable option : unit option
         }
+
+        and Desc = {
+            mutable short : string
+            mutable long : string
+        }
+
+        and Size = {
+            mutable length : int
+            mutable width : int
+            mutable height : int
+        }
+
+    [<RequireQualifiedAccess>]
+    module Immutable =
+
+        type Item = {
+            tags : string list
+            qty : int
+            price : float
+            sale : bool
+            desc : Desc
+            sizes : Size list
+            option : unit option
+        }
+
+        and Desc = {
+            short : string
+            long : string
+        }
+
+        and Size = {
+            length : int
+            width : int
+            height : int
+        }
+
+    type Quiz = {
+        grade : int
+        stats : Stats
+        other : BsonDocument
+    }
+
+    and Stats = {
+        mean : int
+        std : int
+    }
+
+    module Query =
+
+        [<TestFixture>]
+        module Comparison =
+
+            [<Test>]
+            let ``test typed all``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.tags |> Query.all [ "appliances"; "school"; "book" ] @> |> bson @>
+                let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed equal to``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty = 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonInt32(20)) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed greater than``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty > 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$gt", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed greater than or equal to``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty >= 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$gte", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed in``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty |> Query.in' [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed less than``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty < 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed less than or equal to``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty <= 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$lte", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed not equal to``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty <> 20 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$ne", BsonInt32(20))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed not in``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty |> Query.nin [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$nin", BsonArray([5; 15]))) @>
+
+                test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module Logical =
+
+            [<Test>]
+            let ``test typed and``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.price = 1.99 && x.qty < 20 && x.sale = true @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                   BsonDocument("sale", BsonBoolean(true)) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed or``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.price = 1.99 && (x.qty < 20 || x.sale = true) @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                                                   BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed nor``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> Query.nor [ x.price = 1.99; x.qty < 20; x.sale = true ] @> |> bson @>
+                let expected = <@ BsonDocument("$nor", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                                   BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                   BsonDocument("sale", BsonBoolean(true)) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed not``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> not (x.price > 1.99) @> |> bson @>
+                let expected = <@ BsonDocument("price", BsonDocument("$not", BsonDocument("$gt", BsonDouble(1.99)))) @>
+
+                test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module Element =
+
+            [<Test>]
+            let ``test typed exists``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty |> Query.exists && x.qty |> Query.nin [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(true)))
+                                                                   BsonDocument("qty", BsonDocument("$nin", BsonArray([ 5; 15 ]))) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed not exists``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty |> Query.nexists || x.qty |> Query.in' [ 5; 15 ] @> |> bson @>
+                let expected = <@ BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$exists", BsonBoolean(false)))
+                                                                  BsonDocument("qty", BsonDocument("$in", BsonArray([ 5; 15 ]))) ])) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed mod``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.qty % 4 = 0 @> |> bson @>
+                let expected = <@ BsonDocument("qty", BsonDocument("$mod", BsonArray([4; 0]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed type``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.price |> Query.type' BsonType.Double @> |> bson @>
+                let expected = <@ BsonDocument("price", BsonDocument("$type", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module JavaScript =
+
+            [<Test>]
+            let ``test typed where``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x |> Query.where "this.credits == this.debits" @> |> bson @>
+                let expected = <@ BsonDocument("$where", BsonString("this.credits == this.debits")) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed regex``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.desc.short =~ "/acme.*corp/i" @> |> bson @>
+                let expected = <@ BsonDocument("desc.short", BsonDocument([ BsonElement("$regex", BsonString("acme.*corp"))
+                                                                            BsonElement("$options", BsonString("i")) ])) @>
+
+                test <@ %query = %expected @>
+
+        [<TestFixture>]
+        module Array =
+
+            [<Test>]
+            let ``test typed element match``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.sizes |> Query.elemMatch (bson <@ fun (y : Immutable.Size) -> y.length = 1 && y.width > 1 @>) @> |> bson @>
+                let expected = <@ BsonDocument("sizes", BsonDocument("$elemMatch", BsonDocument([ BsonElement("length", BsonInt32(1))
+                                                                                                  BsonElement("width", BsonDocument("$gt", BsonInt32(1))) ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed size``() =
+                let query = <@ <@ fun (x : Immutable.Item) -> x.tags |> Query.size 2 @> |> bson @>
+                let expected = <@ BsonDocument("tags", BsonDocument("$size", BsonInt32(2))) @>
+
+                test <@ %query = %expected @>
 
         [<Test>]
         let ``test property get``() =
-            let query = <@ <@ fun x -> x.price = 1.99 && (x.qty < 20 || x.sale = true) @> |> bson @>
+            let query = <@ <@ fun (x : Immutable.Item) -> x.price = 1.99 && (x.qty < 20 || x.sale = true) @> |> bson @>
             let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
                                                                BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
                                                                                                BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
 
             test <@ %query = %expected @>
-
-        type Quiz = {
-            grade : int
-            stats : QuizStats
-            other : BsonDocument
-        }
-
-        and QuizStats = {
-            mean : int
-            std : int
-        }
 
         [<Test>]
         let ``test property get nested``() =

--- a/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/TypedQuotableMongoTests.fs
@@ -1,0 +1,53 @@
+namespace FSharp.MongoDB.Driver.Tests
+
+open MongoDB.Bson
+
+open NUnit.Framework
+open Swensen.Unquote
+
+open FSharp.MongoDB.Driver.Quotations
+
+module TypedQuotableMongo =
+
+    [<TestFixture>]
+    module Query =
+
+        type Item = {
+            price : double
+            qty : int
+            sale : bool
+        }
+
+        [<Test>]
+        let ``test property get``() =
+            let query = <@ <@ fun x -> x.price = 1.99 && (x.qty < 20 || x.sale = true) @> |> bson @>
+            let expected = <@ BsonDocument("$and", BsonArray([ BsonDocument("price", BsonDouble(1.99))
+                                                               BsonDocument("$or", BsonArray([ BsonDocument("qty", BsonDocument("$lt", BsonInt32(20)))
+                                                                                               BsonDocument("sale", BsonBoolean(true)) ])) ])) @>
+
+            test <@ %query = %expected @>
+
+        type Quiz = {
+            grade : int
+            stats : QuizStats
+            other : BsonDocument
+        }
+
+        and QuizStats = {
+            mean : int
+            std : int
+        }
+
+        [<Test>]
+        let ``test property get nested``() =
+            let query = <@ <@ fun x -> x.stats.mean < 75 @> |> bson @>
+            let expected = <@ BsonDocument("stats.mean", BsonDocument("$lt", BsonInt32(75))) @>
+
+            test <@ %query = %expected @>
+
+        [<Test>]
+        let ``test property get mixed``() =
+            let query = <@ <@ fun x -> x.other?duration = 45 @> |> bson @>
+            let expected = <@ BsonDocument("other.duration", BsonInt32(45)) @>
+
+            test <@ %query = %expected @>


### PR DESCRIPTION
Initial resolution to #1. Does **not** fully-support
- Record types
- Discriminated unions

within quotations.
