### PR TITLE
Define mongo { ... } computation expression

### DIFF
--- a/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
+++ b/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
@@ -7,6 +7,8 @@ open Microsoft.FSharp.Reflection
 
 open MongoDB.Bson
 
+open MongoDB.Driver.Core
+
 open FSharp.MongoDB.Driver.Quotations
 
 module Expression =
@@ -14,37 +16,144 @@ module Expression =
     type IMongoQueryable<'a> =
         inherit seq<'a>
 
+    type IMongoUpdatable<'a> =
+        inherit seq<'a>
+
+    [<RequireQualifiedAccess>]
+    type private TransformResult = // (fun * args * cont)
+       | Query of (Var -> Expr -> BsonElement) * (Var * Expr) * Expr
+       | Update of (Var -> string -> Expr -> BsonElement) * (Var * string * Expr) * Expr
+
+    [<RequireQualifiedAccess>]
+    type private TraverseResult = // (fun * args)
+       | Query of (Var -> Expr -> BsonElement) * (Var * Expr)
+       | Update of (Var -> string -> Expr -> BsonElement) * (Var * string * Expr)
+
+    [<RequireQualifiedAccess>]
+    type MongoOperationResult<'a> =
+       | Query of Scope<'a>
+       | Update of WriteConcernResult
+
     type MongoQueryBuilder() =
 
-        member __.Source (x : seq<'a>) = x :?> IMongoQueryable<'a>
+        let mkCall op args =
+            match <@ ignore %op @> with
+            | SpecificCall <@ ignore @> (_, _, [ Lambdas (_, Call (target, info, _)) ]) ->
+                match target with
+                | Some x -> Expr.Call(x, info, args)
+                | None -> Expr.Call(info, args)
+            | _ -> failwith "unable to acquire methodinfo"
 
-        member __.For (source : IMongoQueryable<'a>, f) = source |> Seq.collect f :?> IMongoQueryable<'a>
+        let rec (|List|_|) expr =
+            match expr with
+            | NewUnionCase (uci, args) when isListUnionCase uci ->
+                match args with
+                | [] -> Some([], typeof<unit>)
+                | [ head; List (tail, _) ] -> Some(head :: tail, typeof<Expr>)
+                | _ -> failwith "unexpected list union case"
 
-        member __.Yield v = [v]
+            | _ -> None
+
+        let (|ValueOrList|_|) expr =
+            match expr with
+            | Value (value, typ) -> Some (value, typ)
+            | List (values, typ) -> Some (box values, typ)
+            | _ -> None
+
+        let transform (x : MongoQueryBuilder) expr =
+            match expr with
+            // Query operations
+            | SpecificCall <@ x.Where @> (_, _, [ cont; Lambda (var, body) ]) ->
+                let res = TransformResult.Query (queryParser, (var, body), cont)
+                Some res
+
+            // Update operations
+            | SpecificCall <@ x.Set @> (_, _, [ cont; Lambda (_, body); ValueOrList (value, typ) ]) ->
+                match body with
+                | GetField (var, field) ->
+                    let res = TransformResult.Update (updateParser, (var, field, Expr.Value value), cont)
+                    Some res
+                | _ -> failwithf "unrecognized expression\n%A" body
+
+            | SpecificCall <@ x.Inc @> (_, _, [ cont; Lambda (_, body); Int32 (value) ]) ->
+                let (var, field, body) =
+                    match body with
+                    | CallDynamic (var, field) -> (var, field, Expr.Coerce(body, typeof<int>))
+                    | GetProperty (var, field) -> (var, field, body)
+                    | _ -> failwithf "unrecognized expression\n%A" body
+
+                let call = mkCall <@ (+) @> [ body; Expr.Value value ]
+                let res = TransformResult.Update (updateParser, (var, field, call), cont)
+                Some res
+
+            | SpecificCall <@ x.Dec @> (_, _, [ cont; Lambda (_, body); Int32 (value) ]) ->
+                let (var, field, body) =
+                    match body with
+                    | CallDynamic (var, field) -> (var, field, Expr.Coerce(body, typeof<int>))
+                    | GetProperty (var, field) -> (var, field, body)
+                    | _ -> failwithf "unrecognized expression\n%A" body
+
+                let call = mkCall <@ (-) @> [ body; Expr.Value value ]
+                let res = TransformResult.Update (updateParser, (var, field, call), cont)
+                Some res
+
+            | _ -> None
+
+        let traverse (x : MongoQueryBuilder) expr =
+            let rec traverse builder expr res =
+                match transform builder expr with
+                | Some trans ->
+                    match trans with
+                    | TransformResult.Query (f, args, cont) ->
+                        let x = TraverseResult.Query (f, args)
+                        traverse builder cont (x :: res)
+
+                    | TransformResult.Update (f, args, cont) ->
+                        let x = TraverseResult.Update (f, args)
+                        traverse builder cont (x :: res)
+
+                | None -> res
+
+            traverse x expr []
+
+        member __.Source (x : #seq<'a>) : IMongoQueryable<'a> = invalidOp "not implemented"
+
+        member __.For (source : IMongoQueryable<'a>, f : 'a -> IMongoQueryable<'a>) = invalidOp "not implemented"
+
+        member __.Zero () : IMongoQueryable<'a> = invalidOp "not implemented"
+
+        member __.Yield x : IMongoQueryable<'a> = invalidOp "not implemented"
 
         member __.Quote (expr : Expr<#seq<'a>>) = expr
 
         member x.Run (expr : Expr<#seq<'a>>) =
-            let rec (|NestedWhere|_|) expr =
-                match expr with
-                // REVIEW: should we $and the conditions together?
-                | SpecificCall <@ x.Where @> (_, _, [ NestedWhere _; q ]) ->
-                    let casted : Expr<'a -> bool> = q |> Expr.Cast
-                    Some casted
+            let elems =
+                traverse x expr
+                |> List.map (fun x ->
+                    match x with
+                    | TraverseResult.Query (f, x) -> x ||> f
+                    | TraverseResult.Update (f, x) -> x |||> f)
 
-                | SpecificCall <@ x.Where @> (_, _, [ _; q ]) ->
-                    let casted : Expr<'a -> bool> = q |> Expr.Cast
-                    Some casted
-
-                | _ -> None
-
-            match expr with
-            | NestedWhere (q) -> bson q
-
-            | _ -> failwith "unsupported operation"
+            BsonDocument(elems)
 
         [<CustomOperation("where", MaintainsVariableSpace = true)>]
-        member __.Where (source : IMongoQueryable<'a>, [<ProjectionParameter>] predicate) =
-            source |> Seq.filter predicate :?> IMongoQueryable<'a>
+        member __.Where (source : IMongoQueryable<'a>, [<ProjectionParameter>] predicate : 'a -> bool) : IMongoQueryable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("update", MaintainsVariableSpace = true)>]
+        member __.Update (source : IMongoQueryable<'a>) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("set", MaintainsVariableSpace = true)>]
+        member __.Set (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("inc", MaintainsVariableSpace = true)>]
+        member __.Inc (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("dec", MaintainsVariableSpace = true)>]
+        member __.Dec (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
 
     let mongo = new MongoQueryBuilder()

--- a/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
+++ b/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
@@ -352,7 +352,7 @@ module Expression =
 
         member __.Source (x : #seq<'a>) : IMongoQueryable<'a> = invalidOp "not implemented"
 
-        member __.For (source : IMongoQueryable<'a>, f : 'a -> IMongoQueryable<'a>) = invalidOp "not implemented"
+        member __.For (source : IMongoQueryable<'a>, f : 'a -> IMongoQueryable<'a>) : IMongoQueryable<'a> = invalidOp "not implemented"
 
         member __.Zero () : IMongoQueryable<'a> = invalidOp "not implemented"
 
@@ -450,7 +450,7 @@ module Expression =
             invalidOp "not implemented"
 
         [<CustomOperation("unset", MaintainsVariableSpace = true)>]
-        member __.Unset (source : #IMongoUpdatable<'a>, [<ProjectionParameter>] field) : IMongoUpdatable<'a> =
+        member __.Unset (source : #IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b option) : IMongoUpdatable<'a> =
             invalidOp "not implemented"
 
         [<CustomOperation("addToSet", MaintainsVariableSpace = true)>]

--- a/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
+++ b/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
@@ -162,7 +162,7 @@ module Expression =
                 prepareDocs expr
 
                 let res =
-                    if !isUpdate then
+                    if !isUpdate then // dereference
                         MongoDeferredOperation.Update (queryDoc, updateDoc)
                     else
                         MongoDeferredOperation.Query queryDoc
@@ -183,16 +183,52 @@ module Expression =
         member __.Update (source : IMongoQueryable<'a>) : IMongoUpdatable<'a> =
             invalidOp "not implemented"
 
-        [<CustomOperation("set", MaintainsVariableSpace = true)>]
-        member __.Set (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
-            invalidOp "not implemented"
-
         [<CustomOperation("inc", MaintainsVariableSpace = true)>]
         member __.Inc (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
             invalidOp "not implemented"
 
         [<CustomOperation("dec", MaintainsVariableSpace = true)>]
         member __.Dec (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("set", MaintainsVariableSpace = true)>]
+        member __.Set (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("unset", MaintainsVariableSpace = true)>]
+        member __.Unset (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("addToSet", MaintainsVariableSpace = true)>]
+        member __.AddToSet (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("popLeft", MaintainsVariableSpace = true)>]
+        member __.PopLeft (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("popRight", MaintainsVariableSpace = true)>]
+        member __.PopRight (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("pull", MaintainsVariableSpace = true)>]
+        member __.Pull (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list, predicate : 'b -> bool) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("pullAll", MaintainsVariableSpace = true)>]
+        member __.PullAll (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list, values : 'b list) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("push", MaintainsVariableSpace = true)>]
+        member __.Push (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b list, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("bitAnd", MaintainsVariableSpace = true)>]
+        member __.BitAnd (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
+            invalidOp "not implemented"
+
+        [<CustomOperation("bitOr", MaintainsVariableSpace = true)>]
+        member __.BitOr (source : IMongoUpdatable<'a>, [<ProjectionParameter>] field : 'a -> 'b, value : 'b) : IMongoUpdatable<'a> =
             invalidOp "not implemented"
 
     let mongo = new MongoBuilder()

--- a/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
+++ b/src/FSharp.MongoDB.Driver/ExpressibleMongo.fs
@@ -1,0 +1,39 @@
+namespace FSharp.MongoDB.Driver
+
+open Microsoft.FSharp.Quotations
+open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
+open Microsoft.FSharp.Reflection
+
+open MongoDB.Bson
+
+open FSharp.MongoDB.Driver.Quotations
+
+module Expression =
+
+    type IMongoQueryable<'a> =
+        inherit seq<'a>
+
+    type MongoQueryBuilder() =
+
+        member __.Source (x : seq<'a>) = x :?> IMongoQueryable<'a>
+
+        member __.For (source : IMongoQueryable<'a>, f) = source |> Seq.collect f :?> IMongoQueryable<'a>
+
+        member __.Yield v = [v]
+
+        member __.Quote (expr : Expr<#seq<'a>>) = expr
+
+        member x.Run (expr : Expr<#seq<'a>>) =
+            match expr with
+            | SpecificCall <@ x.Where @> (_, _, [ _; q ]) ->
+                let casted : Expr<'a -> bool> = q |> Expr.Cast
+                bson casted
+
+            | _ -> failwith "unsupported operation"
+
+        [<CustomOperation("where", MaintainsVariableSpace = true)>]
+        member __.Where (source : IMongoQueryable<'a>, [<ProjectionParameter>] predicate) =
+            source |> Seq.filter predicate :?> IMongoQueryable<'a>
+
+    let mongo = new MongoQueryBuilder()

--- a/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
+++ b/src/FSharp.MongoDB.Driver/FSharp.MongoDB.Driver.fsproj
@@ -83,6 +83,9 @@
     <Compile Include="QuotableMongo.fs">
       <Link>QuotableMongo.fs</Link>
     </Compile>
+    <Compile Include="ExpressibleMongo.fs">
+      <Link>ExpressibleMongo.fs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharp.MongoDB.Bson\FSharp.MongoDB.Bson.fsproj">

--- a/src/FSharp.MongoDB.Driver/MongoCollection.fs
+++ b/src/FSharp.MongoDB.Driver/MongoCollection.fs
@@ -1,5 +1,8 @@
 namespace FSharp.MongoDB.Driver
 
+open System.Collections
+open System.Collections.Generic
+
 open MongoDB.Bson
 open MongoDB.Bson.Serialization
 
@@ -8,6 +11,7 @@ open MongoDB.Driver.Core.Protocol
 
 [<Interface>]
 type IMongoCollection<'DocType> =
+    inherit IEnumerable<'DocType>
 
     abstract member Drop : unit -> #CommandResult
 
@@ -93,3 +97,9 @@ type MongoCollection<'DocType> =
                                                                        AssignIdOnInsert = true}
 
                 x.backbone.Insert x.db x.clctn doc flags settings
+
+    interface IEnumerable<'DocType> with
+        member x.GetEnumerator() = (x :> IMongoCollection<'DocType>).Find().Get()
+
+    interface IEnumerable with
+        member x.GetEnumerator() = (x :> IEnumerable<'DocType>).GetEnumerator() :> IEnumerator

--- a/src/FSharp.MongoDB.Driver/MongoScope.fs
+++ b/src/FSharp.MongoDB.Driver/MongoScope.fs
@@ -87,4 +87,4 @@ type Scope<'DocType> = private {
         member x.GetEnumerator() = x.Get()
 
     interface IEnumerable with
-        override x.GetEnumerator() = (x :> IEnumerable<'DocType>).GetEnumerator() :> IEnumerator
+        member x.GetEnumerator() = (x :> IEnumerable<'DocType>).GetEnumerator() :> IEnumerator

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -67,7 +67,7 @@ module Quotations =
         let sort (x : 'a) (y : 'b list) : 'b list = invalidOp "not implemented"
 
     [<AutoOpen>]
-    module private Helpers =
+    module internal Helpers =
 
         let inline isGenericTypeDefinedFrom<'a> (typ : System.Type) =
             typ.IsGenericType && typ.GetGenericTypeDefinition() = typedefof<'a>
@@ -153,7 +153,7 @@ module Quotations =
 
     let private doc (elem : BsonElement) = BsonDocument(elem)
 
-    let rec private queryParser v q =
+    let rec internal queryParser v q =
         let (|Comparison|_|) op expr =
             match expr with
             | InfixOp op (GetField (var, field), value) when var = v ->
@@ -278,7 +278,7 @@ module Quotations =
 
         | _ -> invalidOp "unrecognized pattern"
 
-    and private updateParser v f q =
+    and internal updateParser v f q =
         let rec (|DeSugared|_|) v f op expr =
             match expr with
             | Lambda (_, SpecificCall <@ %op @> _) ->
@@ -396,7 +396,7 @@ module Quotations =
         | DeSugared var field <@ (|||) @> ([ Int32 (value) ]) ->
             BsonElement("$bit", BsonDocument(field, BsonDocument("or", BsonInt32(value))))
 
-        | _ -> failwith "unrecognized expression"
+        | _ -> failwithf "unrecognized expression\n%A" q
 
     and bson (q : Expr<'a -> 'b>) =
         match box q with

--- a/src/FSharp.MongoDB.Driver/QuotableMongo.fs
+++ b/src/FSharp.MongoDB.Driver/QuotableMongo.fs
@@ -98,14 +98,13 @@ module Quotations =
 
         let rec (|CallDynamic|_|) expr =
             match expr with
-            | SpecificCall <@ (?) @> (_, _, [ Var (var); String (field) ]) ->
+            | SpecificCall <@ (?) @> (_, _, [ Var (var); String (field) ])
+            | Coerce (CallDynamic (var, field), _) ->
                 Some(var, field)
 
-            | SpecificCall <@ (?) @> (_, _, [ CallDynamic (var, subdoc); String (field) ]) ->
+            | SpecificCall <@ (?) @> (_, _, [ CallDynamic (var, subdoc); String (field) ])
+            | SpecificCall <@ (?) @> (_, _, [ GetProperty (var, subdoc); String (field) ]) ->
                 Some(var, sprintf "%s.%s" subdoc field)
-
-            | GetProperty (var, field) ->
-                Some(var, field)
 
             | _ -> None
 

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -8,7 +8,33 @@ open Swensen.Unquote
 open FSharp.MongoDB.Driver.Expression
 open FSharp.MongoDB.Driver.Quotations
 
+open FSharp.MongoDB.Driver
+
 module ExpressibleMongo =
+
+    [<RequireQualifiedAccess>]
+    module Immutable =
+
+        type Item = {
+            tags : string list
+            qty : int
+            price : float
+            sale : bool
+            desc : Desc
+            sizes : Size list
+            option : unit option
+        }
+
+        and Desc = {
+            short : string
+            long : string
+        }
+
+        and Size = {
+            length : int
+            width : int
+            height : int
+        }
 
     module Query =
 
@@ -27,3 +53,105 @@ module ExpressibleMongo =
                 let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
 
                 test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test typed mongo query expression all``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let query = <@ mongo {
+                    for x in clctn do
+                    where ((x : Immutable.Item).tags |> Query.all [ "appliances"; "school"; "book" ])
+                } @>
+
+                let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %query = %expected @>
+
+    module Update =
+
+        [<TestFixture>]
+        module Fields =
+
+            [<Test>]
+            let ``test mongo query expression increment``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    inc x?qty 1
+                } @>
+
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo query expression increment``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    inc (x : Immutable.Item).qty 1
+                } @>
+
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo query expression decrement``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    dec x?qty 2
+                } @>
+
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo query expression decrement``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    dec (x : Immutable.Item).qty 2
+                } @>
+
+                let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo query expression set``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    set x?qty 20
+                } @>
+
+                let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo query expression set``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update = <@ mongo {
+                    for x in clctn do
+                    update
+                    set (x : Immutable.Item).qty 20
+                } @>
+
+                let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %update = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -553,6 +553,148 @@ module ExpressibleMongo =
 
                 test <@ %update = %expected @>
 
+            [<Test>]
+            let ``test mongo workflow add to set with each modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        addToSetEach x?tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow add to set with each modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        addToSetEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow push with each modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pushEach x?tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow push with each modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument("$each", BsonArray([ "appliances"; "school"; "book" ])))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow push with slice modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pushEach x?tags [ "appliances"; "school"; "book" ]
+                                        slice -5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument([ BsonElement("$each", BsonArray([ "appliances"; "school"; "book" ]))
+                                                                                            BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow push with slice modifier``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        slice -5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonDocument([ BsonElement("$each", BsonArray([ "appliances"; "school"; "book" ]))
+                                                                                            BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %update = %expected @>
+
         [<TestFixture>]
         module Bitwise =
 

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -654,8 +654,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach x?tags [ "appliances"; "school"; "book" ]
-                                        slice -5
+                                        pushEach x?tags [ "appliances"; "school"; "book" ]; slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -679,8 +678,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
-                                        slice -5
+                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]; slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -708,9 +706,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach x?sizes [ size1; size2; size3 ]
-                                        sortListBy x?sizes (fun y -> y?width)
-                                        slice -5
+                                        pushEach x?sizes [ size1; size2; size3 ]; sortListBy x?sizes (fun y -> y?width); slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -741,9 +737,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach (x : Immutable.Item).sizes [ size1; size2; size3 ]
-                                        sortListBy (x : Immutable.Item).sizes (fun y -> y.width)
-                                        slice -5
+                                        pushEach (x : Immutable.Item).sizes [ size1; size2; size3 ]; sortListBy (x : Immutable.Item).sizes (fun y -> y.width); slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -228,6 +228,52 @@ module ExpressibleMongo =
 
                 test <@ %update = %expected @>
 
+            [<Test>]
+            let ``test mongo workflow unset``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    unset x?option
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
+
+                let expected = <@ BsonDocument("$unset", BsonDocument("option", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow unset``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    unset (x : Immutable.Item).option
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
+
+                let expected = <@ BsonDocument("$unset", BsonDocument("option", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
         [<TestFixture>]
         module Array =
 

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -1,0 +1,29 @@
+namespace FSharp.MongoDB.Driver.Tests
+
+open MongoDB.Bson
+
+open NUnit.Framework
+open Swensen.Unquote
+
+open FSharp.MongoDB.Driver.Expression
+open FSharp.MongoDB.Driver.Quotations
+
+module ExpressibleMongo =
+
+    module Query =
+
+        [<TestFixture>]
+        module Comparison =
+
+            [<Test>]
+            let ``test mongo query expression all``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let query = <@ mongo {
+                    for x in clctn do
+                    where (x?tags |> Query.all [ "appliances"; "school"; "book" ])
+                } @>
+
+                let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %query = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -71,7 +71,7 @@ module ExpressibleMongo =
                     <@
                         match
                             mongo { for x in clctn do
-                                    where ((x : Immutable.Item).tags |> Query.all [ "appliances"; "school"; "book" ])
+                                    where (x.tags |> Query.all [ "appliances"; "school"; "book" ])
                                     defer
                             } with
                         | MongoOperationResult.Deferred x ->
@@ -122,7 +122,7 @@ module ExpressibleMongo =
                         match
                             mongo { for x in clctn do
                                     update
-                                    inc (x : Immutable.Item).qty 1
+                                    inc x.qty 1
                                     defer
                             } with
                         | MongoOperationResult.Deferred x ->
@@ -168,7 +168,7 @@ module ExpressibleMongo =
                         match
                             mongo { for x in clctn do
                                     update
-                                    dec (x : Immutable.Item).qty 2
+                                    dec x.qty 2
                                     defer
                             } with
                         | MongoOperationResult.Deferred x ->
@@ -214,7 +214,7 @@ module ExpressibleMongo =
                         match
                             mongo { for x in clctn do
                                     update
-                                    set (x : Immutable.Item).qty 20
+                                    set x.qty 20
                                     defer
                             } with
                         | MongoOperationResult.Deferred x ->
@@ -260,7 +260,7 @@ module ExpressibleMongo =
                         match
                             mongo { for x in clctn do
                                     update
-                                    unset (x : Immutable.Item).option
+                                    unset x.option
                                     defer
                             } with
                         | MongoOperationResult.Deferred x ->
@@ -309,7 +309,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        addToSet (x : Immutable.Item).tags "toaster"
+                                        addToSet x.tags "toaster"
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -355,7 +355,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        popLeft (x : Immutable.Item).sizes
+                                        popLeft x.sizes
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -401,7 +401,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        popRight (x : Immutable.Item).sizes
+                                        popRight x.sizes
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -447,7 +447,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pull (x : Immutable.Item).sizes (fun y -> y.height = 75)
+                                        pull x.sizes (fun y -> y.height = 75)
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -493,7 +493,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pullAll (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        pullAll x.tags [ "appliances"; "school"; "book" ]
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -539,7 +539,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        push (x : Immutable.Item).tags "toaster"
+                                        push x.tags "toaster"
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -578,14 +578,14 @@ module ExpressibleMongo =
 
             [<Test>]
             let ``test typed mongo workflow add to set with each modifier``() =
-                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
                         <@
                             match
                                 mongo { for x in clctn do
                                         update
-                                        addToSetEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        addToSetEach x.tags [ "appliances"; "school"; "book" ]
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -624,14 +624,14 @@ module ExpressibleMongo =
 
             [<Test>]
             let ``test typed mongo workflow push with each modifier``() =
-                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
                         <@
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        pushEach x.tags [ "appliances"; "school"; "book" ]
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -671,14 +671,14 @@ module ExpressibleMongo =
 
             [<Test>]
             let ``test typed mongo workflow push with slice modifier``() =
-                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
                         <@
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]; slice -5
+                                        pushEach x.tags [ "appliances"; "school"; "book" ]; slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -737,7 +737,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        pushEach (x : Immutable.Item).sizes [ size1; size2; size3 ]; sortListBy (x : Immutable.Item).sizes (fun y -> y.width); slice -5
+                                        pushEach x.sizes [ size1; size2; size3 ]; sortListBy x.sizes (fun y -> y.width); slice -5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -790,7 +790,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        bitAnd (x : Immutable.Item).qty 5
+                                        bitAnd x.qty 5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->
@@ -836,7 +836,7 @@ module ExpressibleMongo =
                             match
                                 mongo { for x in clctn do
                                         update
-                                        bitOr (x : Immutable.Item).qty 5
+                                        bitOr x.qty 5
                                         defer
                                 } with
                             | MongoOperationResult.Deferred x ->

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -45,10 +45,19 @@ module ExpressibleMongo =
             let ``test mongo query expression all``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
-                let query = <@ mongo {
-                    for x in clctn do
-                    where (x?tags |> Query.all [ "appliances"; "school"; "book" ])
-                } @>
+                let query =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    where (x?tags |> Query.all [ "appliances"; "school"; "book" ])
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Query query -> query
+                            | _ -> failwith "expected query operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
 
@@ -58,10 +67,19 @@ module ExpressibleMongo =
             let ``test typed mongo query expression all``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
-                let query = <@ mongo {
-                    for x in clctn do
-                    where ((x : Immutable.Item).tags |> Query.all [ "appliances"; "school"; "book" ])
-                } @>
+                let query =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    where ((x : Immutable.Item).tags |> Query.all [ "appliances"; "school"; "book" ])
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Query query -> query
+                            | _ -> failwith "expected query operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("tags", BsonDocument("$all", BsonArray([ "appliances"; "school"; "book" ]))) @>
 
@@ -76,11 +94,20 @@ module ExpressibleMongo =
             let ``test mongo query expression increment``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    inc x?qty 1
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    inc x?qty 1
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
 
@@ -90,11 +117,20 @@ module ExpressibleMongo =
             let ``test typed mongo query expression increment``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    inc (x : Immutable.Item).qty 1
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    inc (x : Immutable.Item).qty 1
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(1))) @>
 
@@ -104,11 +140,20 @@ module ExpressibleMongo =
             let ``test mongo query expression decrement``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    dec x?qty 2
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    dec x?qty 2
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
 
@@ -118,11 +163,20 @@ module ExpressibleMongo =
             let ``test typed mongo query expression decrement``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    dec (x : Immutable.Item).qty 2
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    dec (x : Immutable.Item).qty 2
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$inc", BsonDocument("qty", BsonInt32(-2))) @>
 
@@ -132,11 +186,20 @@ module ExpressibleMongo =
             let ``test mongo query expression set``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    set x?qty 20
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    set x?qty 20
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
 
@@ -146,11 +209,20 @@ module ExpressibleMongo =
             let ``test typed mongo query expression set``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
-                let update = <@ mongo {
-                    for x in clctn do
-                    update
-                    set (x : Immutable.Item).qty 20
-                } @>
+                let update =
+                    <@
+                        match
+                            mongo { for x in clctn do
+                                    update
+                                    set (x : Immutable.Item).qty 20
+                                    defer
+                            } with
+                        | MongoOperationResult.Deferred x ->
+                            match x with
+                            | MongoDeferredOperation.Update (_, update) -> update
+                            | _ -> failwith "expected update operation"
+                        | _ -> failwith "expected deferred result"
+                    @>
 
                 let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
 

--- a/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/ExpressibleMongoTests.fs
@@ -42,7 +42,7 @@ module ExpressibleMongo =
         module Comparison =
 
             [<Test>]
-            let ``test mongo query expression all``() =
+            let ``test mongo workflow all``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
                 let query =
@@ -64,7 +64,7 @@ module ExpressibleMongo =
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test typed mongo query expression all``() =
+            let ``test typed mongo workflow all``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let query =
@@ -91,7 +91,7 @@ module ExpressibleMongo =
         module Fields =
 
             [<Test>]
-            let ``test mongo query expression increment``() =
+            let ``test mongo workflow increment``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
                 let update =
@@ -114,7 +114,7 @@ module ExpressibleMongo =
                 test <@ %update = %expected @>
 
             [<Test>]
-            let ``test typed mongo query expression increment``() =
+            let ``test typed mongo workflow increment``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
@@ -137,7 +137,7 @@ module ExpressibleMongo =
                 test <@ %update = %expected @>
 
             [<Test>]
-            let ``test mongo query expression decrement``() =
+            let ``test mongo workflow decrement``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
                 let update =
@@ -160,7 +160,7 @@ module ExpressibleMongo =
                 test <@ %update = %expected @>
 
             [<Test>]
-            let ``test typed mongo query expression decrement``() =
+            let ``test typed mongo workflow decrement``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
@@ -183,7 +183,7 @@ module ExpressibleMongo =
                 test <@ %update = %expected @>
 
             [<Test>]
-            let ``test mongo query expression set``() =
+            let ``test mongo workflow set``() =
                 let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
 
                 let update =
@@ -206,7 +206,7 @@ module ExpressibleMongo =
                 test <@ %update = %expected @>
 
             [<Test>]
-            let ``test typed mongo query expression set``() =
+            let ``test typed mongo workflow set``() =
                 let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
 
                 let update =
@@ -225,5 +225,379 @@ module ExpressibleMongo =
                     @>
 
                 let expected = <@ BsonDocument("$set", BsonDocument("qty", BsonInt32(20))) @>
+
+                test <@ %update = %expected @>
+
+        [<TestFixture>]
+        module Array =
+
+            [<Test>]
+            let ``test mongo workflow add to set``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        addToSet x?tags "toaster"
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow add to set``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        addToSet (x : Immutable.Item).tags "toaster"
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow pop left``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        popLeft x?sizes
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(-1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow pop left``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        popLeft (x : Immutable.Item).sizes
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(-1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow pop right``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        popRight x?sizes
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow pop right``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        popRight (x : Immutable.Item).sizes
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pop", BsonDocument("sizes", BsonInt32(1))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow pull``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pull x?sizes (fun y -> y?height = 75)
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pull", BsonDocument("sizes", BsonDocument("height", BsonInt32(75)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow pull``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pull (x : Immutable.Item).sizes (fun y -> y.height = 75)
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pull", BsonDocument("sizes", BsonDocument("height", BsonInt32(75)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow pull all``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pullAll x?tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pullAll", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow pull all``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        pullAll (x : Immutable.Item).tags [ "appliances"; "school"; "book" ]
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$pullAll", BsonDocument("tags", BsonArray([ "appliances"; "school"; "book" ]))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow push``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        push x?tags "toaster"
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow push``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        push (x : Immutable.Item).tags "toaster"
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$push", BsonDocument("tags", BsonString("toaster"))) @>
+
+                test <@ %update = %expected @>
+
+        [<TestFixture>]
+        module Bitwise =
+
+            [<Test>]
+            let ``test mongo workflow bitwise and``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        bitAnd x?qty 5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow bitwise and``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        bitAnd (x : Immutable.Item).qty 5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test mongo workflow bitwise or``() =
+                let clctn : seq<BsonDocument> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        bitOr x?qty 5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %update = %expected @>
+
+            [<Test>]
+            let ``test typed mongo workflow bitwise or``() =
+                let clctn : seq<Immutable.Item> = Seq.empty |> Seq.cast
+
+                let update =
+                        <@
+                            match
+                                mongo { for x in clctn do
+                                        update
+                                        bitOr (x : Immutable.Item).qty 5
+                                        defer
+                                } with
+                            | MongoOperationResult.Deferred x ->
+                                match x with
+                                | MongoDeferredOperation.Update (_, update) -> update
+                                | _ -> failwith "expected update operation"
+                            | _ -> failwith "expected deferred result"
+                        @>
+
+                let expected = <@ BsonDocument("$bit", BsonDocument("qty", BsonDocument("or", BsonInt32(5)))) @>
 
                 test <@ %update = %expected @>

--- a/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
+++ b/tests/FSharp.MongoDB.Driver.Tests/FSharp.MongoDB.Driver.Tests.fsproj
@@ -58,6 +58,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExpressibleMongoTests.fs">
+      <Link>ExpressibleMongoTests.fs</Link>
+    </Compile>
     <Compile Include="MongoBackboneTests.fs">
       <Link>MongoBackboneTests.fs</Link>
     </Compile>

--- a/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
+++ b/tests/FSharp.MongoDB.Driver.Tests/QuotableMongoTests.fs
@@ -189,15 +189,43 @@ module QuotableMongo =
         module Fields =
 
             [<Test>]
-            let ``test increment``() =
+            let ``test sugared increment``() =
                 let query = <@ <@ fun x -> [ x?age <- (+) 1 ] @> |> bson @>
                 let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(1))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test decrement``() =
+            let ``test unsugared increment``() =
+                let query = <@ <@ fun x -> [ x?age <- x?age |> (+) 1 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared increment infix``() =
+                let query = <@ <@ fun x -> [ x?age <- x?age + 1 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared decrement``() =
                 let query = <@ <@ fun x -> [ x?age <- (-) 2 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(-2))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared decrement``() =
+                let query = <@ <@ fun x -> [ x?age <- x?age |> (-) 2 ] @> |> bson @>
+                let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(-2))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared decrement infix``() =
+                let query = <@ <@ fun x -> [ x?age <- x?age - 2 ] @> |> bson @>
                 let expected = <@ BsonDocument("$inc", BsonDocument("age", BsonInt32(-2))) @>
 
                 test <@ %query = %expected @>
@@ -242,63 +270,119 @@ module QuotableMongo =
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test add to set``() =
+            let ``test sugared add to set``() =
                 let query = <@ <@ fun x -> [ x?scores <- Update.addToSet 89 ] @> |> bson @>
                 let expected = <@ BsonDocument("$addToSet", BsonDocument("scores", BsonInt32(89))) @>
 
                 test <@  %query = %expected @>
 
             [<Test>]
-            let ``test pop left``() =
+            let ``test unsugared add to set``() =
+                let query = <@ <@ fun x -> [ x?scores <- x?scores |> Update.addToSet 89 ] @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("scores", BsonInt32(89))) @>
+
+                test <@  %query = %expected @>
+
+            [<Test>]
+            let ``test sugared pop left``() =
                 let query = <@ <@ fun x -> [ x?field <- Update.popleft ] @> |> bson @>
                 let expected = <@ BsonDocument("$pop", BsonDocument("field", BsonInt32(-1))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test pop right``() =
+            let ``test unsugared pop left``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field |> Update.popleft ] @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("field", BsonInt32(-1))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared pop right``() =
                 let query = <@ <@ fun x -> [ x?field <- Update.popright ] @> |> bson @>
                 let expected = <@ BsonDocument("$pop", BsonDocument("field", BsonInt32(1))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test pull``() =
+            let ``test unsugared pop right``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field |> Update.popright ] @> |> bson @>
+                let expected = <@ BsonDocument("$pop", BsonDocument("field", BsonInt32(1))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared pull``() =
                 let query = <@ <@ fun x -> [ x?grades <- Update.pull (bson <@ fun y -> y?mean = 75 @>) ] @> |> bson @>
                 let expected = <@ BsonDocument("$pull", BsonDocument("grades", BsonDocument("mean", BsonInt32(75)))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test pull all``() =
+            let ``test unsugared pull``() =
+                let query = <@ <@ fun x -> [ x?grades <- x?grades |> Update.pull (bson <@ fun y -> y?mean = 75 @>) ] @> |> bson @>
+                let expected = <@ BsonDocument("$pull", BsonDocument("grades", BsonDocument("mean", BsonInt32(75)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared pull all``() =
                 let query = <@ <@ fun x -> [ x?grades <- Update.pullAll [ 80; 88; 85 ] ] @> |> bson @>
                 let expected = <@ BsonDocument("$pullAll", BsonDocument("grades", BsonArray([ 80; 88; 85 ]))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test push``() =
+            let ``test unsugared pull all``() =
+                let query = <@ <@ fun x -> [ x?grades <- x?grades |> Update.pullAll [ 80; 88; 85 ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$pullAll", BsonDocument("grades", BsonArray([ 80; 88; 85 ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared push``() =
                 let query = <@ <@ fun x -> [ x?scores <- Update.push 89 ] @> |> bson @>
                 let expected = <@ BsonDocument("$push", BsonDocument("scores", BsonInt32(89))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test add to set with each modifier``() =
+            let ``test unsugared push``() =
+                let query = <@ <@ fun x -> [ x?scores <- x?scores |> Update.push 89 ] @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("scores", BsonInt32(89))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared add to set with each modifier``() =
                 let query = <@ <@ fun x -> [ x?grades <- Update.each Update.addToSet [ 80; 78; 86 ] ] @> |> bson @>
                 let expected = <@ BsonDocument("$addToSet", BsonDocument("grades", BsonDocument("$each", BsonArray([ 80; 78; 86 ])))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test push with each modifier``() =
+            let ``test unsugared add to set with each modifier``() =
+                let query = <@ <@ fun x -> [ x?grades <- x?grades |> Update.each Update.addToSet [ 80; 78; 86 ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$addToSet", BsonDocument("grades", BsonDocument("$each", BsonArray([ 80; 78; 86 ])))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared push with each modifier``() =
                 let query = <@ <@ fun x -> [ x?grades <- Update.each Update.push [ 80; 78; 86 ] ] @> |> bson @>
                 let expected = <@ BsonDocument("$push", BsonDocument("grades", BsonDocument("$each", BsonArray([ 80; 78; 86 ])))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test push with slice modifier``() =
+            let ``test unsugared push with each modifier``() =
+                let query = <@ <@ fun x -> [ x?grades <- x?grades |> Update.each Update.push [ 80; 78; 86 ] ] @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("grades", BsonDocument("$each", BsonArray([ 80; 78; 86 ])))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared push with slice modifier``() =
                 let query = <@ <@ fun x -> [ x?grades <- Update.each Update.push [ 80; 78; 86 ] >> Update.slice -5 ] @> |> bson @>
                 let expected = <@ BsonDocument("$push", BsonDocument("grades", BsonDocument([ BsonElement("$each", BsonArray([ 80; 78; 86 ]))
                                                                                               BsonElement("$slice", BsonInt32(-5)) ]))) @>
@@ -306,7 +390,15 @@ module QuotableMongo =
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test push with sort modifier``() =
+            let ``test unsugared push with slice modifier``() =
+                let query = <@ <@ fun x -> [ x?grades <- x?grades |> Update.each Update.push [ 80; 78; 86 ] |> Update.slice -5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$push", BsonDocument("grades", BsonDocument([ BsonElement("$each", BsonArray([ 80; 78; 86 ]))
+                                                                                              BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared push with sort modifier``() =
                 let quiz3 = BsonDocument([ BsonElement("id", BsonInt32(3)); BsonElement("score", BsonInt32(8)) ])
                 let quiz4 = BsonDocument([ BsonElement("id", BsonInt32(4)); BsonElement("score", BsonInt32(7)) ])
                 let quiz5 = BsonDocument([ BsonElement("id", BsonInt32(5)); BsonElement("score", BsonInt32(6)) ])
@@ -322,19 +414,64 @@ module QuotableMongo =
 
                 test <@ %query = %expected @>
 
+            [<Test>]
+            let ``test unsugared push with sort modifier``() =
+                let quiz3 = BsonDocument([ BsonElement("id", BsonInt32(3)); BsonElement("score", BsonInt32(8)) ])
+                let quiz4 = BsonDocument([ BsonElement("id", BsonInt32(4)); BsonElement("score", BsonInt32(7)) ])
+                let quiz5 = BsonDocument([ BsonElement("id", BsonInt32(5)); BsonElement("score", BsonInt32(6)) ])
+
+                let query = <@ <@ fun (x : BsonDocument) -> [ x?quizzes <- x?quizzes |> Update.each Update.push [ quiz3; quiz4; quiz5 ]
+                                                                                     |> Update.sort (bson <@ fun (y : BsonDocument) -> y?score = 1 @>)
+                                                                                     |> Update.slice -5 ] @> |> bson @>
+
+                let expected =
+                    <@ BsonDocument("$push", BsonDocument("quizzes", BsonDocument([ BsonElement("$each", BsonArray([ quiz3; quiz4; quiz5 ]))
+                                                                                    BsonElement("$sort", BsonDocument("score", BsonInt32(1)))
+                                                                                    BsonElement("$slice", BsonInt32(-5)) ]))) @>
+
+                test <@ %query = %expected @>
+
         [<TestFixture>]
         module Bitwise =
 
             [<Test>]
-            let ``test bitwise and``() =
+            let ``test sugared bitwise and``() =
                 let query = <@ <@ fun x -> [ x?field <- (&&&) 5 ] @> |> bson @>
                 let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("and", BsonInt32(5)))) @>
 
                 test <@ %query = %expected @>
 
             [<Test>]
-            let ``test bitwise or``() =
+            let ``test unsugared bitwise and``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field |> (&&&) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared bitwise and infix``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field &&& 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("and", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test sugared bitwise or``() =
                 let query = <@ <@ fun x -> [ x?field <- (|||) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared bitwise or``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field |> (|||) 5 ] @> |> bson @>
+                let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("or", BsonInt32(5)))) @>
+
+                test <@ %query = %expected @>
+
+            [<Test>]
+            let ``test unsugared bitwise or infix``() =
+                let query = <@ <@ fun x -> [ x?field <- x?field ||| 5 ] @> |> bson @>
                 let expected = <@ BsonDocument("$bit", BsonDocument("field", BsonDocument("or", BsonInt32(5)))) @>
 
                 test <@ %query = %expected @>


### PR DESCRIPTION
Able to build query and update documents using the `defer` custom operation. Otherwise, the query form creates a `Scope<'DocType>` instance, and the update form executes the operation and returns the `WriteConcernResult`.

Note that not all operators defined in the Fluent Spec are support as of yet.

Resolves #12.
